### PR TITLE
Additional fixes for SA1600-SA1602

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -30,12 +30,12 @@
         {
             var testCodeWithoutDocumentation = @"
 {0} {1}
-Foo
+TypeName
 {{
 }}";
             var testCodeWithDocumentation = @"/// <summary> A summary. </summary>
 {0} {1}
-Foo
+TypeName
 {{
 }}";
 
@@ -69,7 +69,7 @@ public class OuterClass
 {{
 
     {0} {1}
-    Foo
+    TypeName
     {{
     }}
 }}";
@@ -80,7 +80,7 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0} {1}
-    Foo
+    TypeName
     {{
     }}
 }}";
@@ -110,12 +110,12 @@ public class OuterClass
         {
             var testCodeWithoutDocumentation = @"
 {0} delegate void
-Foo()
+DelegateName()
 {{
 }}";
             var testCodeWithDocumentation = @"/// <summary> A summary. </summary>
 {0} delegate void
-Foo()
+DelegateName()
 {{
 }}";
 
@@ -149,7 +149,7 @@ public class OuterClass
 {{
 
     {0} delegate void
-    Foo()
+    DelegateName()
     {{
     }}
 }}";
@@ -160,7 +160,7 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0} delegate void
-    Foo()
+    DelegateName()
     {{
     }}
 }}";
@@ -195,7 +195,7 @@ public class OuterClass
 {{
 
     {0} void
-    Foo()
+    MemberName()
     {{
     }}
 }}";
@@ -206,7 +206,7 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0} void
-    Foo()
+    MemberName()
     {{
     }}
 }}";
@@ -237,22 +237,22 @@ public class OuterClass
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
 
     void
-    Foo()
+    MemberName()
     {{
     }}
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
     /// <summary>A summary.</summary>
     void
-    Foo()
+    MemberName()
     {
     }
 }}";
@@ -283,11 +283,11 @@ public interface Interface
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
 
     
-    string Foo
+    string MemberName
     {
         get; set;
     }
@@ -295,11 +295,11 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
     /// <summary>A summary.</summary>
     
-    string Foo
+    string MemberName
     {
         get; set;
     }
@@ -331,11 +331,11 @@ public interface Interface
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
 
     
-    string Foo
+    string MemberName
     {
         add; remove;
     }
@@ -343,11 +343,11 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
     /// <summary>A summary.</summary>
     
-    string Foo
+    string MemberName
     {
         add; remove;
     }
@@ -380,20 +380,20 @@ public interface Interface
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
 
     string
-    this[string foo] { get; set; }
+    this[string key] { get; set; }
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interface Interface
+public interface InterfaceName
 {{
     /// <summary>A summary.</summary>
     string
-    this[string foo] { get; set; }
+    this[string key] { get; set; }
 }}";
 
             DiagnosticResult[] expected;
@@ -516,7 +516,7 @@ public class OuterClass
 {{
 
     {0}
-    string Foo {{ get; set; }}
+    string MemberName {{ get; set; }}
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
@@ -525,7 +525,7 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0}
-    string Foo {{ get; set; }}
+    string MemberName {{ get; set; }}
 }}";
 
             DiagnosticResult[] expected;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -186,7 +186,7 @@ public class OuterClass
             await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        private async Task TestMethodDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
+        private async Task TestMethodDeclarationDocumentation(string modifiers, bool isExplicitInterfaceMethod, bool requiresDiagnostic, bool hasDocumentation)
         {
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
@@ -194,7 +194,7 @@ public class OuterClass
 public class OuterClass
 {{
 
-    {0} void
+    {0} void{1}
     MemberName()
     {{
     }}
@@ -205,7 +205,7 @@ public class OuterClass
 public class OuterClass
 {{
     /// <summary>A summary.</summary>
-    {0} void
+    {0} void{1}
     MemberName()
     {{
     }}
@@ -229,7 +229,8 @@ public class OuterClass
                     }
                 };
 
-            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            string explicitInterfaceText = isExplicitInterfaceMethod ? " IInterface." : string.Empty;
+            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
         private async Task TestInterfaceMethodDeclarationDocumentation(bool hasDocumentation)
@@ -513,7 +514,7 @@ public class OuterClass
             await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        private async Task TestPropertyDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
+        private async Task TestPropertyDeclarationDocumentation(string modifiers, bool isExplicitInterfaceProperty, bool requiresDiagnostic, bool hasDocumentation)
         {
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
@@ -522,7 +523,8 @@ public class OuterClass
 {{
 
     {0}
-    string MemberName {{ get; set; }}
+    string{1}
+    MemberName {{ get; set; }}
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
@@ -531,7 +533,8 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0}
-    string MemberName {{ get; set; }}
+    string{1}
+    MemberName {{ get; set; }}
 }}";
 
             DiagnosticResult[] expected;
@@ -547,15 +550,16 @@ public class OuterClass
                         Locations =
                             new[]
                             {
-                                new DiagnosticResultLocation("Test0.cs", 8, 12)
+                                new DiagnosticResultLocation("Test0.cs", 9, 5)
                             }
                     }
                 };
 
-            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            string explicitInterfaceText = isExplicitInterfaceProperty ? " IInterface." : string.Empty;
+            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        private async Task TestIndexerDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
+        private async Task TestIndexerDeclarationDocumentation(string modifiers, bool isExplicitInterfaceIndexer, bool requiresDiagnostic, bool hasDocumentation)
         {
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
@@ -564,7 +568,8 @@ public class OuterClass
 {{
 
     {0}
-    string this[string key] {{ get {{ return ""; }} set {{ }} }}
+    string{1}
+    this[string key] {{ get {{ return ""; }} set {{ }} }}
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
@@ -573,7 +578,8 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0}
-    string this[string key] {{ get {{ return ""; }} set {{ }} }}
+    string{1}
+    this[string key] {{ get {{ return ""; }} set {{ }} }}
 }}";
 
             DiagnosticResult[] expected;
@@ -589,15 +595,16 @@ public class OuterClass
                         Locations =
                             new[]
                             {
-                                new DiagnosticResultLocation("Test0.cs", 8, 12)
+                                new DiagnosticResultLocation("Test0.cs", 9, 5)
                             }
                     }
                 };
 
-            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            string explicitInterfaceText = isExplicitInterfaceIndexer ? " IInterface." : string.Empty;
+            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        private async Task TestEventDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
+        private async Task TestEventDeclarationDocumentation(string modifiers, bool isExplicitInterfaceEvent, bool requiresDiagnostic, bool hasDocumentation)
         {
             var testCodeWithoutDocumentation = @"    /// <summary>
     /// A summary
@@ -607,7 +614,8 @@ public class OuterClass
     System.Action _myEvent;
 
     {0}
-    event System.Action MyEvent
+    event System.Action{1}
+    MyEvent
     {{
         add
         {{
@@ -627,7 +635,8 @@ public class OuterClass
     System.Action _myEvent;
     /// <summary>A summary.</summary>
     {0}
-    event System.Action MyEvent
+    event System.Action{1}
+    MyEvent
     {{
         add
         {{
@@ -653,12 +662,13 @@ public class OuterClass
                         Locations =
                             new[]
                             {
-                                new DiagnosticResultLocation("Test0.cs", 9, 25)
+                                new DiagnosticResultLocation("Test0.cs", 10, 5)
                             }
                     }
                 };
 
-            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            string explicitInterfaceText = isExplicitInterfaceEvent ? " IInterface." : string.Empty;
+            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
         private async Task TestFieldDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -887,12 +897,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestMethodWithoutDocumentation()
         {
-            await TestMethodDeclarationDocumentation(string.Empty, false, false);
-            await TestMethodDeclarationDocumentation("private", false, false);
-            await TestMethodDeclarationDocumentation("protected", true, false);
-            await TestMethodDeclarationDocumentation("internal", true, false);
-            await TestMethodDeclarationDocumentation("protected internal", true, false);
-            await TestMethodDeclarationDocumentation("public", true, false);
+            await TestMethodDeclarationDocumentation(string.Empty, false, false, false);
+            await TestMethodDeclarationDocumentation(string.Empty, true, true, false);
+            await TestMethodDeclarationDocumentation("private", false, false, false);
+            await TestMethodDeclarationDocumentation("protected", false, true, false);
+            await TestMethodDeclarationDocumentation("internal", false, true, false);
+            await TestMethodDeclarationDocumentation("protected internal", false, true, false);
+            await TestMethodDeclarationDocumentation("public", false, true, false);
 
             await TestInterfaceMethodDeclarationDocumentation(false);
         }
@@ -900,12 +911,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestMethodWithDocumentation()
         {
-            await TestMethodDeclarationDocumentation(string.Empty, false, true);
-            await TestMethodDeclarationDocumentation("private", false, true);
-            await TestMethodDeclarationDocumentation("protected", false, true);
-            await TestMethodDeclarationDocumentation("internal", false, true);
-            await TestMethodDeclarationDocumentation("protected internal", false, true);
-            await TestMethodDeclarationDocumentation("public", false, true);
+            await TestMethodDeclarationDocumentation(string.Empty, false, false, true);
+            await TestMethodDeclarationDocumentation(string.Empty, true, false, true);
+            await TestMethodDeclarationDocumentation("private", false, false, true);
+            await TestMethodDeclarationDocumentation("protected", false, false, true);
+            await TestMethodDeclarationDocumentation("internal", false, false, true);
+            await TestMethodDeclarationDocumentation("protected internal", false, false, true);
+            await TestMethodDeclarationDocumentation("public", false, false, true);
 
             await TestInterfaceMethodDeclarationDocumentation(true);
         }
@@ -969,12 +981,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestPropertyWithoutDocumentation()
         {
-            await TestPropertyDeclarationDocumentation(string.Empty, false, false);
-            await TestPropertyDeclarationDocumentation("private", false, false);
-            await TestPropertyDeclarationDocumentation("protected", true, false);
-            await TestPropertyDeclarationDocumentation("internal", true, false);
-            await TestPropertyDeclarationDocumentation("protected internal", true, false);
-            await TestPropertyDeclarationDocumentation("public", true, false);
+            await TestPropertyDeclarationDocumentation(string.Empty, false, false, false);
+            await TestPropertyDeclarationDocumentation(string.Empty, true, true, false);
+            await TestPropertyDeclarationDocumentation("private", false, false, false);
+            await TestPropertyDeclarationDocumentation("protected", false, true, false);
+            await TestPropertyDeclarationDocumentation("internal", false, true, false);
+            await TestPropertyDeclarationDocumentation("protected internal", false, true, false);
+            await TestPropertyDeclarationDocumentation("public", false, true, false);
 
             await TestInterfacePropertyDeclarationDocumentation(false);
         }
@@ -982,12 +995,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestPropertyWithDocumentation()
         {
-            await TestPropertyDeclarationDocumentation(string.Empty, false, true);
-            await TestPropertyDeclarationDocumentation("private", false, true);
-            await TestPropertyDeclarationDocumentation("protected", false, true);
-            await TestPropertyDeclarationDocumentation("internal", false, true);
-            await TestPropertyDeclarationDocumentation("protected internal", false, true);
-            await TestPropertyDeclarationDocumentation("public", false, true);
+            await TestPropertyDeclarationDocumentation(string.Empty, false, false, true);
+            await TestPropertyDeclarationDocumentation(string.Empty, true, false, true);
+            await TestPropertyDeclarationDocumentation("private", false, false, true);
+            await TestPropertyDeclarationDocumentation("protected", false, false, true);
+            await TestPropertyDeclarationDocumentation("internal", false, false, true);
+            await TestPropertyDeclarationDocumentation("protected internal", false, false, true);
+            await TestPropertyDeclarationDocumentation("public", false, false, true);
 
             await TestInterfacePropertyDeclarationDocumentation(true);
         }
@@ -995,12 +1009,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestIndexerWithoutDocumentation()
         {
-            await TestIndexerDeclarationDocumentation(string.Empty, false, false);
-            await TestIndexerDeclarationDocumentation("private", false, false);
-            await TestIndexerDeclarationDocumentation("protected", true, false);
-            await TestIndexerDeclarationDocumentation("internal", true, false);
-            await TestIndexerDeclarationDocumentation("protected internal", true, false);
-            await TestIndexerDeclarationDocumentation("public", true, false);
+            await TestIndexerDeclarationDocumentation(string.Empty, false, false, false);
+            await TestIndexerDeclarationDocumentation(string.Empty, true, true, false);
+            await TestIndexerDeclarationDocumentation("private", false, false, false);
+            await TestIndexerDeclarationDocumentation("protected", false, true, false);
+            await TestIndexerDeclarationDocumentation("internal", false, true, false);
+            await TestIndexerDeclarationDocumentation("protected internal", false, true, false);
+            await TestIndexerDeclarationDocumentation("public", false, true, false);
 
             await TestInterfaceIndexerDeclarationDocumentation(false);
         }
@@ -1008,12 +1023,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestIndexerWithDocumentation()
         {
-            await TestIndexerDeclarationDocumentation(string.Empty, false, true);
-            await TestIndexerDeclarationDocumentation("private", false, true);
-            await TestIndexerDeclarationDocumentation("protected", false, true);
-            await TestIndexerDeclarationDocumentation("internal", false, true);
-            await TestIndexerDeclarationDocumentation("protected internal", false, true);
-            await TestIndexerDeclarationDocumentation("public", false, true);
+            await TestIndexerDeclarationDocumentation(string.Empty, false, false, true);
+            await TestIndexerDeclarationDocumentation(string.Empty, true, false, true);
+            await TestIndexerDeclarationDocumentation("private", false, false, true);
+            await TestIndexerDeclarationDocumentation("protected", false, false, true);
+            await TestIndexerDeclarationDocumentation("internal", false, false, true);
+            await TestIndexerDeclarationDocumentation("protected internal", false, false, true);
+            await TestIndexerDeclarationDocumentation("public", false, false, true);
 
             await TestInterfaceIndexerDeclarationDocumentation(true);
         }
@@ -1021,12 +1037,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestEventWithoutDocumentation()
         {
-            await TestEventDeclarationDocumentation(string.Empty, false, false);
-            await TestEventDeclarationDocumentation("private", false, false);
-            await TestEventDeclarationDocumentation("protected", true, false);
-            await TestEventDeclarationDocumentation("internal", true, false);
-            await TestEventDeclarationDocumentation("protected internal", true, false);
-            await TestEventDeclarationDocumentation("public", true, false);
+            await TestEventDeclarationDocumentation(string.Empty, false, false, false);
+            await TestEventDeclarationDocumentation(string.Empty, true, true, false);
+            await TestEventDeclarationDocumentation("private", false, false, false);
+            await TestEventDeclarationDocumentation("protected", false, true, false);
+            await TestEventDeclarationDocumentation("internal", false, true, false);
+            await TestEventDeclarationDocumentation("protected internal", false, true, false);
+            await TestEventDeclarationDocumentation("public", false, true, false);
 
             await TestInterfaceEventDeclarationDocumentation(false);
         }
@@ -1034,12 +1051,13 @@ public class OuterClass
         [TestMethod]
         public async Task TestEventWithDocumentation()
         {
-            await TestEventDeclarationDocumentation(string.Empty, false, true);
-            await TestEventDeclarationDocumentation("private", false, true);
-            await TestEventDeclarationDocumentation("protected", false, true);
-            await TestEventDeclarationDocumentation("internal", false, true);
-            await TestEventDeclarationDocumentation("protected internal", false, true);
-            await TestEventDeclarationDocumentation("public", false, true);
+            await TestEventDeclarationDocumentation(string.Empty, false, false, true);
+            await TestEventDeclarationDocumentation(string.Empty, true, false, true);
+            await TestEventDeclarationDocumentation("private", false, false, true);
+            await TestEventDeclarationDocumentation("protected", false, false, true);
+            await TestEventDeclarationDocumentation("internal", false, false, true);
+            await TestEventDeclarationDocumentation("protected internal", false, false, true);
+            await TestEventDeclarationDocumentation("public", false, false, true);
 
             await TestInterfaceEventDeclarationDocumentation(true);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -463,6 +463,50 @@ public class OuterClass
             await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        private async Task TestDestructorDeclarationDocumentation(bool requiresDiagnostic, bool hasDocumentation)
+        {
+            var testCodeWithoutDocumentation = @"    /// <summary>
+    /// A summary
+    /// </summary>
+public class OuterClass
+{{
+
+    ~OuterClass()
+    {{
+    }}
+}}";
+            var testCodeWithDocumentation = @"    /// <summary>
+    /// A summary
+    /// </summary>
+public class OuterClass
+{{
+    /// <summary>A summary.</summary>
+    ~OuterClass()
+    {{
+    }}
+}}";
+
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = DiagnosticId,
+                        Message = "Elements must be documented",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 7, 6)
+                            }
+                    }
+                };
+
+            await VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+        }
+
         private async Task TestPropertyDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
         {
             var testCodeWithoutDocumentation = @"    /// <summary>
@@ -880,6 +924,18 @@ public class OuterClass
             await TestConstructorDeclarationDocumentation("internal", false, true);
             await TestConstructorDeclarationDocumentation("protected internal", false, true);
             await TestConstructorDeclarationDocumentation("public", false, true);
+        }
+
+        [TestMethod]
+        public async Task TestDestructorWithoutDocumentation()
+        {
+            await TestDestructorDeclarationDocumentation(true, false);
+        }
+
+        [TestMethod]
+        public async Task TestDestructorWithDocumentation()
+        {
+            await TestDestructorDeclarationDocumentation(false, true);
         }
 
         [TestMethod]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -335,10 +335,7 @@ public interface InterfaceName
 {{
 
     
-    string MemberName
-    {
-        add; remove;
-    }
+    event System.Action MemberName;
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
@@ -347,10 +344,7 @@ public interface InterfaceName
 {{
     /// <summary>A summary.</summary>
     
-    string MemberName
-    {
-        add; remove;
-    }
+    event System.Action MemberName;
 }}";
 
 
@@ -367,7 +361,19 @@ public interface InterfaceName
                         Locations =
                             new[]
                             {
-                                new DiagnosticResultLocation("Test0.cs", 8, 12)
+                                new DiagnosticResultLocation("Test0.cs", 8, 25)
+                            }
+                    },
+                    // Workaround because the diagnostic is called twice for the SyntaxNode
+                    new DiagnosticResult
+                    {
+                        Id = DiagnosticId,
+                        Message = "Elements must be documented",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 8, 25)
                             }
                     }
                 };
@@ -558,7 +564,7 @@ public class OuterClass
 {{
 
     {0}
-    string this {{ get {{ return ""; }} set {{ }} }}
+    string this[string key] {{ get {{ return ""; }} set {{ }} }}
 }}";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
@@ -567,7 +573,7 @@ public class OuterClass
 {{
     /// <summary>A summary.</summary>
     {0}
-    string this {{ get {{ return ""; }} set {{ }} }}
+    string this[string key] {{ get {{ return ""; }} set {{ }} }}
 }}";
 
             DiagnosticResult[] expected;
@@ -598,7 +604,7 @@ public class OuterClass
     /// </summary>
 public class OuterClass
 {{
-    event System.Action _myEvent;
+    System.Action _myEvent;
 
     {0}
     event System.Action MyEvent
@@ -618,7 +624,7 @@ public class OuterClass
     /// </summary>
 public class OuterClass
 {{
-    event System.Action _myEvent;
+    System.Action _myEvent;
     /// <summary>A summary.</summary>
     {0}
     event System.Action MyEvent

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -248,7 +248,7 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interace Interface
+public interface Interface
 {{
     /// <summary>A summary.</summary>
     void
@@ -295,7 +295,7 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interace Interface
+public interface Interface
 {{
     /// <summary>A summary.</summary>
     
@@ -343,7 +343,7 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interace Interface
+public interface Interface
 {{
     /// <summary>A summary.</summary>
     
@@ -389,7 +389,7 @@ public interface Interface
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public interace Interface
+public interface Interface
 {{
     /// <summary>A summary.</summary>
     string

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -33,7 +33,7 @@
 /// <summary>
 /// Some Documentation
 /// </summary>
-public partial {0} Foo
+public partial {0} TypeName
 {{
 }}";
             await VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), EmptyDiagnosticResults, CancellationToken.None);
@@ -46,7 +46,7 @@ public partial {0} Foo
         {
             var testCode = @"
 public partial {0}
-Foo
+TypeName
 {{
 }}";
 
@@ -80,7 +80,7 @@ Foo
 /// 
 /// </summary>
 public partial {0} 
-Foo
+TypeName
 {{
 }}";
 
@@ -113,12 +113,12 @@ Foo
 /// <summary>
 /// Some Documentation
 /// </summary>
-public partial class Foo
+public partial class TypeName
 {{
     /// <summary>
     /// Some Documentation
     /// </summary>
-    partial void Foo();
+    partial void MemberName();
 }}";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
@@ -130,9 +130,9 @@ public partial class Foo
 /// <summary>
 /// Some Documentation
 /// </summary>
-public partial class Foo
+public partial class TypeName
 {{
-    partial void Foo();
+    partial void MemberName();
 }}";
 
             DiagnosticResult[] expected;
@@ -163,12 +163,12 @@ public partial class Foo
 /// <summary>
 /// Some Documentation
 /// </summary>
-public partial class Foo
+public partial class TypeName
 {{
     /// <summary>
     /// 
     /// </summary>
-    partial void Foo();
+    partial void MemberName();
 }}";
 
             DiagnosticResult[] expected;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -33,7 +33,7 @@
 /// <summary>
 /// Some Documentation
 /// </summary>
-enum Foo
+enum TypeName
 {{
     /// <summary>
     /// Some Documentation
@@ -47,7 +47,7 @@ enum Foo
         public async Task TestEnumWithoutDocumentation()
         {
             var testCode = @"
-enum Foo
+enum TypeName
 {{
     Bar
 }}";
@@ -79,7 +79,7 @@ enum Foo
 /// <summary>
 /// Some Documentation
 /// </summary>
-enum Foo
+enum TypeName
 {{
     /// <summary>
     /// 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -56,6 +56,7 @@
             context.RegisterSyntaxNodeAction(HandleTypeDeclaration, SyntaxKind.EnumDeclaration);
             context.RegisterSyntaxNodeAction(HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
             context.RegisterSyntaxNodeAction(HandleConstructorDeclaration, SyntaxKind.ConstructorDeclaration);
+            context.RegisterSyntaxNodeAction(HandleDestructorDeclaration, SyntaxKind.DestructorDeclaration);
             context.RegisterSyntaxNodeAction(HandlePropertyDeclaration, SyntaxKind.PropertyDeclaration);
             context.RegisterSyntaxNodeAction(HandleIndexerDeclaration, SyntaxKind.IndexerDeclaration);
             context.RegisterSyntaxNodeAction(HandleFieldDeclaration, SyntaxKind.FieldDeclaration);
@@ -103,6 +104,19 @@
             ConstructorDeclarationSyntax declaration = context.Node as ConstructorDeclarationSyntax;
 
             if (declaration != null && NeedsComment(declaration.Modifiers, SyntaxKind.PrivateKeyword))
+            {
+                if (!XmlCommentHelper.HasDocumentation(declaration))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, declaration.Identifier.GetLocation()));
+                }
+            }
+        }
+
+        private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            DestructorDeclarationSyntax declaration = context.Node as DestructorDeclarationSyntax;
+
+            if (declaration != null)
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -85,7 +85,7 @@
             MethodDeclarationSyntax declaration = context.Node as MethodDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -130,7 +130,7 @@
             PropertyDeclarationSyntax declaration = context.Node as PropertyDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -151,7 +151,7 @@
             IndexerDeclarationSyntax declaration = context.Node as IndexerDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -222,7 +222,7 @@
             EventFieldDeclarationSyntax declaration = context.Node as EventFieldDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration))
+            if (IsInterfaceMemberDeclaration(declaration))
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -265,17 +265,9 @@
             return delegateDeclaration?.Parent is BaseTypeDeclarationSyntax;
         }
 
-        private bool IsDeclaredInInterface(SyntaxNode parent)
+        private bool IsInterfaceMemberDeclaration(SyntaxNode declaration)
         {
-            if (parent == null)
-            {
-                return false;
-            }
-            if (parent is InterfaceDeclarationSyntax)
-            {
-                return true;
-            }
-            return IsDeclaredInInterface(parent.Parent);
+            return declaration?.Parent is InterfaceDeclarationSyntax;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -201,14 +201,8 @@
         private void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
         {
             EventDeclarationSyntax declaration = context.Node as EventDeclarationSyntax;
-            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration))
-            {
-                defaultVisibility = SyntaxKind.PublicKeyword;
-            }
-
-            if (declaration != null && NeedsComment(declaration.Modifiers, defaultVisibility))
+            if (declaration != null && NeedsComment(declaration.Modifiers, SyntaxKind.PrivateKeyword))
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {
@@ -220,9 +214,16 @@
         private void HandleEventFieldDeclaration(SyntaxNodeAnalysisContext context)
         {
             EventFieldDeclarationSyntax declaration = context.Node as EventFieldDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (IsDeclaredInInterface(declaration))
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
             var variableDeclaration = declaration?.Declaration;
 
-            if (variableDeclaration != null && NeedsComment(declaration.Modifiers, SyntaxKind.PrivateKeyword))
+            if (variableDeclaration != null && NeedsComment(declaration.Modifiers, defaultVisibility))
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -85,7 +85,7 @@
             MethodDeclarationSyntax declaration = context.Node as MethodDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration))
+            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -130,7 +130,7 @@
             PropertyDeclarationSyntax declaration = context.Node as PropertyDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration))
+            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -151,7 +151,7 @@
             IndexerDeclarationSyntax declaration = context.Node as IndexerDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (IsDeclaredInInterface(declaration))
+            if (IsDeclaredInInterface(declaration) || declaration.ExplicitInterfaceSpecifier != null)
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -201,8 +201,14 @@
         private void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
         {
             EventDeclarationSyntax declaration = context.Node as EventDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (declaration != null && NeedsComment(declaration.Modifiers, SyntaxKind.PrivateKeyword))
+            if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            if (declaration != null && NeedsComment(declaration.Modifiers, defaultVisibility))
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -69,7 +69,7 @@
         {
             BaseTypeDeclarationSyntax declaration = context.Node as BaseTypeDeclarationSyntax;
 
-            bool isNestedInClassOrStruct = IsNestedInClassOrStructRecursive(declaration.Parent);
+            bool isNestedInClassOrStruct = IsNestedType(declaration);
 
             if (declaration != null && NeedsComment(declaration.Modifiers, isNestedInClassOrStruct ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword))
             {
@@ -187,7 +187,7 @@
         {
             DelegateDeclarationSyntax declaration = context.Node as DelegateDeclarationSyntax;
 
-            bool isNestedInClassOrStruct = IsNestedInClassOrStructRecursive(declaration.Parent);
+            bool isNestedInClassOrStruct = IsNestedType(declaration);
 
             if (declaration != null && NeedsComment(declaration.Modifiers, isNestedInClassOrStruct ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword))
             {
@@ -248,17 +248,14 @@
                 && !modifiers.Any(SyntaxKind.PartialKeyword);
         }
 
-        private bool IsNestedInClassOrStructRecursive(SyntaxNode parent)
+        private bool IsNestedType(BaseTypeDeclarationSyntax typeDeclaration)
         {
-            if (parent == null)
-            {
-                return false;
-            }
-            if (parent is BaseTypeDeclarationSyntax)
-            {
-                return true;
-            }
-            return IsNestedInClassOrStructRecursive(parent.Parent);
+            return typeDeclaration?.Parent is BaseTypeDeclarationSyntax;
+        }
+
+        private bool IsNestedType(DelegateDeclarationSyntax delegateDeclaration)
+        {
+            return delegateDeclaration?.Parent is BaseTypeDeclarationSyntax;
         }
 
         private bool IsDeclaredInInterface(SyntaxNode parent)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
@@ -91,13 +91,13 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(HandleClassDeclaration, SyntaxKind.ClassDeclaration);
-            context.RegisterSyntaxNodeAction(HandleClassDeclaration, SyntaxKind.InterfaceDeclaration);
-            context.RegisterSyntaxNodeAction(HandleClassDeclaration, SyntaxKind.StructDeclaration);
+            context.RegisterSyntaxNodeAction(HandleTypeDeclaration, SyntaxKind.ClassDeclaration);
+            context.RegisterSyntaxNodeAction(HandleTypeDeclaration, SyntaxKind.InterfaceDeclaration);
+            context.RegisterSyntaxNodeAction(HandleTypeDeclaration, SyntaxKind.StructDeclaration);
             context.RegisterSyntaxNodeAction(HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
         }
 
-        private void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
         {
             TypeDeclarationSyntax typeDeclaration = context.Node as TypeDeclarationSyntax;
             if (typeDeclaration != null)


### PR DESCRIPTION
This pull request includes several tweaks to the implementation and tests for SA1600 (plus a couple minor things for SA1601 and SA1602).
- Include finalizers in SA1600 analysis
- Simplify analysis for nested types
- Fix syntax errors and [spelling warnings](http://vsspellchecker.codeplex.com/) in unit tests
- Fix handling of events declared in interfaces
- Add handling for explicitly implemented interface members

Accepting this pull request will merge the changes into your `SA1600` branch, which will then automatically update DotNetAnalyzers/StyleCopAnalyzers#370 to include the changes.
