### PR TITLE
Updates to implementation of SA1604-SA1607

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -47,6 +47,16 @@
             await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        private async Task TestTypeWithInheritedDocumentation(string typeName)
+        {
+            var testCode = @"
+/// <inheritdoc/>
+{0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+        }
+
         private async Task TestTypeWithoutDocumentation(string typeName)
         {
             var testCode = @"
@@ -98,6 +108,30 @@ TypeName
         public async Task TestInterfaceWithDocumentation()
         {
             await TestTypeWithDocumentation("interface");
+        }
+
+        [TestMethod]
+        public async Task TestEnumWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("enum");
+        }
+
+        [TestMethod]
+        public async Task TestClassWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("class");
+        }
+
+        [TestMethod]
+        public async Task TestStructWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("struct");
+        }
+
+        [TestMethod]
+        public async Task TestInterfaceWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("interface");
         }
 
         [TestMethod]
@@ -170,6 +204,16 @@ TypeName();";
         }
 
         [TestMethod]
+        public async Task TestDelegateWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <inheritdoc/>
+public delegate 
+TypeName();";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestDelegateWithoutDocumentation()
         {
             var testCode = @"
@@ -223,6 +267,21 @@ public class ClassName
     /// <summary>
     ///
     /// </summary>
+    public void Test() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public void Test() { }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -293,6 +352,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestConstructorWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestConstructorWithoutDocumentation()
         {
             var testCode = @"
@@ -357,6 +431,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestDestructorWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    ~ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestDestructorWithoutDocumentation()
         {
             var testCode = @"
@@ -401,6 +490,21 @@ public class ClassName
     /// <summary>
     ///
     /// </summary>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestPropertyWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -471,6 +575,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestIndexerWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public ClassName this[string t] { get { return null; } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestIndexerNoDocumentation()
         {
             var testCode = @"
@@ -529,6 +648,21 @@ public class ClassName
     /// <summary>
     ///
     /// </summary>
+    public ClassName Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestFieldWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public ClassName Foo;
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -610,6 +744,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestEventWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public event System.Action Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestEventNoDocumentation()
         {
             var testCode = @"
@@ -679,6 +828,21 @@ public interface InterfaceName
     /// <summary>
     ///
     /// </summary>
+    event System.Action Foo { add; remove; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestEventPropertyWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public interface InterfaceName
+{
+    /// <inheritdoc/>
     event System.Action Foo { add; remove; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -59,6 +59,16 @@ partial {0} TypeName
             await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        private async Task TestTypeWithInheritedDocumentation(string typeName)
+        {
+            var testCode = @"
+/// <inheritdoc/>
+partial {0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+        }
+
         private async Task TestTypeWithoutDocumentation(string typeName)
         {
             var testCode = @"
@@ -122,6 +132,24 @@ TypeName
         public async Task TestInterfaceWithContentDocumentation()
         {
             await TestTypeWithContentDocumentation("interface");
+        }
+
+        [TestMethod]
+        public async Task TestClassWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("class");
+        }
+
+        [TestMethod]
+        public async Task TestStructWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("struct");
+        }
+
+        [TestMethod]
+        public async Task TestInterfaceWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("interface");
         }
 
         [TestMethod]
@@ -209,6 +237,21 @@ public class ClassName
     /// <content>
     ///
     /// </content>
+    partial void Test();
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     partial void Test();
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -47,6 +47,16 @@
             await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        private async Task TestTypeWithInheritedDocumentation(string typeName)
+        {
+            var testCode = @"
+/// <inheritdoc/>
+{0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+        }
+
         private async Task TestTypeWithoutDocumentation(string typeName)
         {
             var testCode = @"
@@ -100,6 +110,30 @@ TypeName
         public async Task TestInterfaceWithDocumentation()
         {
             await TestTypeWithDocumentation("interface");
+        }
+
+        [TestMethod]
+        public async Task TestEnumWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("enum");
+        }
+
+        [TestMethod]
+        public async Task TestClassWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("class");
+        }
+
+        [TestMethod]
+        public async Task TestStructWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("struct");
+        }
+
+        [TestMethod]
+        public async Task TestInterfaceWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("interface");
         }
 
         [TestMethod]
@@ -172,6 +206,16 @@ TypeName();";
         }
 
         [TestMethod]
+        public async Task TestDelegateWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <inheritdoc/>
+public delegate 
+TypeName();";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestDelegateWithoutDocumentation()
         {
             var testCode = @"
@@ -227,6 +271,21 @@ public class ClassName
     /// <summary>
     /// Foo
     /// </summary>
+    public void Test() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public void Test() { }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -299,6 +358,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestConstructorWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestConstructorWithoutDocumentation()
         {
             var testCode = @"
@@ -365,6 +439,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestDestructorWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    ~ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestDestructorWithoutDocumentation()
         {
             var testCode = @"
@@ -411,6 +500,21 @@ public class ClassName
     /// <summary>
     /// Foo
     /// </summary>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestPropertyWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -483,6 +587,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestIndexerWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public ClassName this[string t] { get { return null; } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestIndexerNoDocumentation()
         {
             var testCode = @"
@@ -543,6 +662,21 @@ public class ClassName
     /// <summary>
     /// Foo
     /// </summary>
+    public ClassName Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestFieldWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     public ClassName Foo;
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
@@ -626,6 +760,21 @@ public class ClassName
         }
 
         [TestMethod]
+        public async Task TestEventWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
+    public event System.Action Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestEventNoDocumentation()
         {
             var testCode = @"
@@ -697,6 +846,21 @@ public interface InterfaceName
     /// <summary>
     /// Foo
     /// </summary>
+    event System.Action Foo { add; remove; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestEventPropertyWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public interface InterfaceName
+{
+    /// <inheritdoc/>
     event System.Action Foo { add; remove; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -222,12 +222,6 @@ TypeName
         }
 
         [TestMethod]
-        public async Task TestEnumNoDocumentation()
-        {
-            await TestTypeNoDocumentation("enum");
-        }
-
-        [TestMethod]
         public async Task TestClassNoDocumentation()
         {
             await TestTypeNoDocumentation("class");

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -59,6 +59,16 @@ partial {0} TypeName
             await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        private async Task TestTypeWithInheritedDocumentation(string typeName)
+        {
+            var testCode = @"
+/// <inheritdoc/>
+partial {0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+        }
+
         private async Task TestTypeWithoutSummaryDocumentation(string typeName)
         {
             var testCode = @"
@@ -155,6 +165,24 @@ TypeName
         public async Task TestInterfaceWithContentDocumentation()
         {
             await TestTypeWithContentDocumentation("interface");
+        }
+
+        [TestMethod]
+        public async Task TestClassWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("class");
+        }
+
+        [TestMethod]
+        public async Task TestStructWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("struct");
+        }
+
+        [TestMethod]
+        public async Task TestInterfaceWithInheritedDocumentation()
+        {
+            await TestTypeWithInheritedDocumentation("interface");
         }
 
         [TestMethod]
@@ -260,6 +288,21 @@ public class ClassName
     /// <content>
     /// Foo
     /// </content>
+    partial void Test();
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithInheritedDocumentation()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <inheritdoc/>
     partial void Test();
 }";
             await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
@@ -28,132 +28,121 @@ namespace StyleCop.Analyzers.DocumentationRules
             context.RegisterSyntaxNodeAction(HandleFieldDeclaration, SyntaxKind.EventFieldDeclaration);
         }
 
+        private static XmlElementSyntax GetTopLevelElement(DocumentationCommentTriviaSyntax syntax, string tagName)
+        {
+            return syntax.Content.OfType<XmlElementSyntax>().FirstOrDefault(element => string.Equals(element.StartTag.Name.ToString(), tagName));
+        }
+
         private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as BaseTypeDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
             if (node.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
+                // partial elements are handled by PartialElementDocumentationSummaryBase
                 return;
             }
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as DelegateDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as MethodDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
             if (node.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
+                // partial elements are handled by PartialElementDocumentationSummaryBase
                 return;
             }
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as ConstructorDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as DestructorDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as PropertyDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
-            }
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
         private void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as IndexerDeclarationSyntax;
+            if (node == null || node.ThisKeyword.IsMissing)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.ThisKeyword.GetLocation());
-            }
+            HandleDeclaration(context, node, node.ThisKeyword.GetLocation());
         }
 
         private void HandleFieldDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as BaseFieldDeclarationSyntax;
+            if (node == null || node.Declaration == null)
+                return;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null && node.Declaration != null)
-            {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
+            var locations =
+                from variable in node.Declaration.Variables
+                let identifier = variable.Identifier
+                where !identifier.IsMissing
+                select identifier.GetLocation();
 
-                var locations = node.Declaration.Variables.Select(v => v.Identifier.GetLocation()).ToArray();
-                HandleXmlElement(context, xmlElement, locations);
-            }
+            HandleDeclaration(context, node, locations.ToArray());
         }
 
         private void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as EventDeclarationSyntax;
+            if (node == null || node.Identifier.IsMissing)
+                return;
 
+            HandleDeclaration(context, node, node.Identifier.GetLocation());
+        }
+
+        private void HandleDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, params Location[] locations)
+        {
             var documentation = XmlCommentHelper.GetDocumentationStructure(node);
-            if (documentation != null)
+            if (documentation == null)
             {
-                var xmlElement = documentation.Content.OfType<XmlElementSyntax>().FirstOrDefault(x => x.StartTag.Name.ToString() == XmlCommentHelper.SummaryXmlTag);
-
-                HandleXmlElement(context, xmlElement, node.Identifier.GetLocation());
+                // missing documentation is reported by SA1600, SA1601, and SA1602
+                return;
             }
+
+            var summaryXmlElement = GetTopLevelElement(documentation, XmlCommentHelper.SummaryXmlTag);
+            HandleXmlElement(context, summaryXmlElement, locations);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
@@ -43,7 +43,7 @@
             }
         }
 
-        protected internal override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax syntax, Location[] diagnosticLocations)
+        protected internal override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location[] diagnosticLocations)
         {
             if (syntax == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
@@ -90,7 +90,7 @@
             }
         }
 
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax syntax, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location[] diagnosticLocations)
         {
             if (syntax == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
@@ -45,7 +45,7 @@
             }
         }
 
-        protected internal override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax syntax, Location[] diagnosticLocations)
+        protected internal override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location[] diagnosticLocations)
         {
             if (syntax != null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
@@ -88,7 +88,7 @@
             }
         }
 
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax syntax, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location[] diagnosticLocations)
         {
             if (syntax != null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -13,7 +13,7 @@
     {
         internal const string SummaryXmlTag = "summary";
         internal const string ContentXmlTag = "content";
-
+        internal const string InheritdocXmlTag = "inheritdoc";
 
         /// <summary>
         /// This helper is used by documentation diagnostics to check if a xml comment should be considered empty.


### PR DESCRIPTION
This pull request includes the following updates:
1. Refactor common code
2. Ignore elements which are documented with `<inheritdoc/>`
3. Remove a test for `partial enum` (which is not valid in C#)

Accepting this pull request will merge it into your `SA1604` branch, which will automatically update DotNetAnalyzers/StyleCopAnalyzers#405 to include the changes.
